### PR TITLE
Fixed anyconfig exception while loading of configuration files

### DIFF
--- a/examples/collections.yml
+++ b/examples/collections.yml
@@ -1,39 +1,40 @@
 ---
 
-- name: collection-A
-  available: true
-  accept_all_content: true
-  type: DATA_SET
+collections:
+  - name: collection-A
+    available: true
+    accept_all_content: true
+    type: DATA_SET
 
-  service_ids:
-    - inbox_a
-    - collection_management_a
-    - poll_a
+    service_ids:
+      - inbox_a
+      - collection_management_a
+      - poll_a
 
-- name: collection-B
-  available: true
-  accept_all_content: false
-  supported_content:
-    - urn:stix.mitre.org:xml:1.1.1
-  service_ids:
-    - inbox_a
-    - inbox_b
-    - collection_management_a
-    - poll_a
+  - name: collection-B
+    available: true
+    accept_all_content: false
+    supported_content:
+      - urn:stix.mitre.org:xml:1.1.1
+    service_ids:
+      - inbox_a
+      - inbox_b
+      - collection_management_a
+      - poll_a
 
-- name: collection-C
-  available: true
-  accept_all_content: false
-  supported_content:
-    - urn:stix.mitre.org:xml:1.1.1
-    - urn:custom.bindings.com:json:0.0.1
-  service_ids:
-    - inbox_a
-    - collection_management_a
-    - poll_a
+  - name: collection-C
+    available: true
+    accept_all_content: false
+    supported_content:
+      - urn:stix.mitre.org:xml:1.1.1
+      - urn:custom.bindings.com:json:0.0.1
+    service_ids:
+      - inbox_a
+      - collection_management_a
+      - poll_a
 
-- name: collection-D
-  available: false
-  service_ids:
-    - inbox_b
-    - collection_management_a
+  - name: collection-D
+    available: false
+    service_ids:
+      - inbox_b
+      - collection_management_a

--- a/examples/services.yml
+++ b/examples/services.yml
@@ -1,58 +1,59 @@
 ---
 
-- id: inbox_a
-  type: inbox
-  address: /services/inbox-a
-  description: Custom Inbox Service Description A
-  destination_collection_required: yes
-  accept_all_content: yes
-  authentication_required: no
-  protocol_bindings:
-    - urn:taxii.mitre.org:protocol:http:1.0
+services:
+  - id: inbox_a
+    type: inbox
+    address: /services/inbox-a
+    description: Custom Inbox Service Description A
+    destination_collection_required: yes
+    accept_all_content: yes
+    authentication_required: no
+    protocol_bindings:
+      - urn:taxii.mitre.org:protocol:http:1.0
 
-- id: inbox_b
-  type: inbox
-  address: /services/inbox-b
-  description: Custom Inbox Service Description B
-  destination_collection_required: yes
-  accept_all_content: no
-  authentication_required: yes
-  supported_content:
-    - urn:stix.mitre.org:xml:1.1.1
-    - urn:custom.example.com:json:0.0.1
-  protocol_bindings:
-    - urn:taxii.mitre.org:protocol:http:1.0
+  - id: inbox_b
+    type: inbox
+    address: /services/inbox-b
+    description: Custom Inbox Service Description B
+    destination_collection_required: yes
+    accept_all_content: no
+    authentication_required: yes
+    supported_content:
+      - urn:stix.mitre.org:xml:1.1.1
+      - urn:custom.example.com:json:0.0.1
+    protocol_bindings:
+      - urn:taxii.mitre.org:protocol:http:1.0
 
-- id: discovery_a
-  type: discovery
-  address: /services/discovery-a
-  description: Custom Discovery Service description
-  advertised_services:
-    - inbox_a
-    - inbox_b
-    - discovery_a
-    - collection_management_a
-    - poll_a
-  protocol_bindings:
-    - urn:taxii.mitre.org:protocol:http:1.0
-    - urn:taxii.mitre.org:protocol:https:1.0
+  - id: discovery_a
+    type: discovery
+    address: /services/discovery-a
+    description: Custom Discovery Service description
+    advertised_services:
+      - inbox_a
+      - inbox_b
+      - discovery_a
+      - collection_management_a
+      - poll_a
+    protocol_bindings:
+      - urn:taxii.mitre.org:protocol:http:1.0
+      - urn:taxii.mitre.org:protocol:https:1.0
 
-- id: collection_management_a
-  type: collection_management
-  address: /services/collection-management-a
-  description: Custom Collection Management Service description
-  protocol_bindings:
-    - urn:taxii.mitre.org:protocol:http:1.0
-    - urn:taxii.mitre.org:protocol:https:1.0
+  - id: collection_management_a
+    type: collection_management
+    address: /services/collection-management-a
+    description: Custom Collection Management Service description
+    protocol_bindings:
+      - urn:taxii.mitre.org:protocol:http:1.0
+      - urn:taxii.mitre.org:protocol:https:1.0
 
-- id: poll_a
-  type: poll
-  address: /services/poll-a
-  description: Custom Poll Service description
-  subscription_required: no
-  max_result_count: 100
-  max_result_size: 10
-  authentication_required: yes
-  protocol_bindings:
-    - urn:taxii.mitre.org:protocol:http:1.0
+  - id: poll_a
+    type: poll
+    address: /services/poll-a
+    description: Custom Poll Service description
+    subscription_required: no
+    max_result_count: 100
+    max_result_size: 10
+    authentication_required: yes
+    protocol_bindings:
+      - urn:taxii.mitre.org:protocol:http:1.0
 

--- a/opentaxii/cli/persistence.py
+++ b/opentaxii/cli/persistence.py
@@ -21,11 +21,12 @@ def create_services():
 
     args = parser.parse_args()
     services_config = anyconfig.load(args.config, forced_type="yaml")
+    services = services_config.get('services', [])
 
     with app.app_context():
 
         app.taxii_server.persistence.create_services_from_object(
-            services_config)
+            services)
 
 
 def create_collections():
@@ -41,11 +42,12 @@ def create_collections():
 
     args = parser.parse_args()
     collections_config = anyconfig.load(args.config, forced_type="yaml")
+    collections = collections_config.get('collections', [])
 
     with app.app_context():
 
         created = 0
-        for collection in collections_config:
+        for collection in collections:
 
             service_ids = collection.pop('service_ids')
             existing = None


### PR DESCRIPTION
OpenTAXII uses anyconfig to parse configiration files for creating services and collections. OpenTAXII expects to get list-like object from anyconfig.
But anyconfig is designed to return dict-like object. So latest version of anyconfig raises exception
"ValueError" when parses examples of configuration files.
```
./bin/opentaxii-create-collections -c services.yml
<<cut>>
ValueError: dictionary update sequence element #0 has length 8; 2 is required
```
anyconfig binary fails as well
```
./bin/anyconfig_cli -I yaml services.yml
<<cut>>
ValueError: dictionary update sequence element #0 has length 8; 2 is required
```
To avoid this error need to use old version of anyconfig.

So config files should be fixed (make it dict-like to be compatible with anyconfig)
It can be done as
`{ID1: SERVICE_OBJ1, ID2: SERVICE_OBJ2, ...  }`
or
`{ 'services': [SERVICE_OBJ1, SERVICE_OBJ2, ...]}`

Was choosen 2nd variant because:

1. It avoids multiple usage and misunderstanding of id's (`ID1` and `SERVICE_OBJ.id`)
2. List of objects remains in the same order as before (possible it can be important)
3. These configuration files can be easy merged in future if needed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eclecticiq/opentaxii/62)
<!-- Reviewable:end -->
