### PR TITLE
Split host and port args in taxii-poll usage doc

### DIFF
--- a/docs/auth.rst
+++ b/docs/auth.rst
@@ -46,7 +46,8 @@ Example request using `Cabby library <http://github.com/eclecticiq/cabby>`_ CLI 
 
     # using JWT support in Cabby
     (venv) $ taxii-poll \
-                --host localhost:9000 \
+                --host localhost \
+                --port 9000 \
                 --path /services/poll-a \
                 --collection collection-A \
                 --username test \


### PR DESCRIPTION
taxii-poll appears to need --host and --port to be separate args.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eclecticiq/opentaxii/65)
<!-- Reviewable:end -->
