### PR TITLE
Fixed error creating services using YAML config

### DIFF
--- a/opentaxii/persistence/manager.py
+++ b/opentaxii/persistence/manager.py
@@ -59,7 +59,7 @@ class PersistenceManager(object):
         '''
 
         for blob in services_config:
-            service = blob_to_service_entity(blob)
+            service = blob_to_service_entity(services_config[blob])
             self.create_service(service)
 
             log.info("service.created", id=service.id, type=service.type)

--- a/opentaxii/persistence/manager.py
+++ b/opentaxii/persistence/manager.py
@@ -59,7 +59,7 @@ class PersistenceManager(object):
         '''
 
         for blob in services_config:
-            service = blob_to_service_entity(services_config[blob])
+            service = blob_to_service_entity(services_config[blob][0])
             self.create_service(service)
 
             log.info("service.created", id=service.id, type=service.type)

--- a/opentaxii/taxii/converters.py
+++ b/opentaxii/taxii/converters.py
@@ -329,7 +329,7 @@ def content_block_entity_to_content_block(entity, version):
 
 def blob_to_service_entity(blob):
 
-    properties = dict(blob[0])
+    properties = dict(blob)
     _id = properties.pop('id')
     _type = properties.pop('type')
 

--- a/opentaxii/taxii/converters.py
+++ b/opentaxii/taxii/converters.py
@@ -329,7 +329,7 @@ def content_block_entity_to_content_block(entity, version):
 
 def blob_to_service_entity(blob):
 
-    properties = dict(blob)
+    properties = dict(blob[0])
     _id = properties.pop('id')
     _type = properties.pop('type')
 


### PR DESCRIPTION
In the configuration documentation, Step 2 asks the user to run:
`opentaxii-create-services -c services.yml`

which throws the following error (even when using the provided YAML config).
`ValueError: dictionary update sequence element #0 has length 1; 2 is required`

That error was just due to a dict key "services" being passed instead of a the value (dict object) itself.

Easy to fix.  :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eclecticiq/opentaxii/72)
<!-- Reviewable:end -->
