### PR TITLE
fix datetime error when insert data to mysql

### DIFF
--- a/opentaxii/persistence/sqldb/api.py
+++ b/opentaxii/persistence/sqldb/api.py
@@ -235,7 +235,7 @@ class SQLDatabaseAPI(OpenTAXIIPersistenceAPI):
             subtype = None
 
         content = ContentBlock(
-            timestamp_label=entity.timestamp_label,
+            timestamp_label=entity.timestamp_label.strftime('%Y-%m-%d %H:%M:%S'),
             inbox_message_id=entity.inbox_message_id,
             content=entity.content,
             binding_id=binding,


### PR DESCRIPTION
fix error about exception when insert data to mysql:
"Incorrect datetime value: '2017-06-28 02:33:55.423124+00:00' for column 'timestamp_label' at row 1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eclecticiq/opentaxii/75)
<!-- Reviewable:end -->
