### PR TITLE
Fixed a typo in docs/docker.rst

### DIFF
--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -41,7 +41,7 @@ Setting up  authentication is done with the following two variables:
 .. code-block:: shell
 
     $ export OPENTAXII_PASS="SomePassword"
-    $ docker -d -p 9000:9000 -e OPENTAXII_USER=myuser -e OPENTAXII_PASS eclecticiq/opentaxii
+    $ docker run -d -p 9000:9000 -e OPENTAXII_USER=myuser -e OPENTAXII_PASS eclecticiq/opentaxii
 
 ---------------------
 


### PR DESCRIPTION
`run` command is missing in `docs/docker.rst`#L44

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eclecticiq/opentaxii/87)
<!-- Reviewable:end -->
