### PR TITLE
Removing print functions for remote work

### DIFF
--- a/examples/hooks.py
+++ b/examples/hooks.py
@@ -6,18 +6,15 @@ from opentaxii.signals import (
 
 def post_create_content_block(manager, content_block, collection_ids,
                               service_id):
-    print('Content block id={} (collections={}, service_id={}) was created'
-          .format(content_block.id, ', '.join(map(str, collection_ids)),
-                  service_id))
+    pass
 
 
 def post_create_inbox_message(manager, inbox_message):
-    print('Inbox message id={} was created'.format(inbox_message.id))
+    pass
 
 
 def post_create_subscription(manager, subscription):
-    print('Subscription id={} (service_id={}) was created'
-          .format(subscription.id, subscription.service_id))
+    pass
 
 
 CONTENT_BLOCK_CREATED.connect(post_create_content_block)

--- a/opentaxii/utils.py
+++ b/opentaxii/utils.py
@@ -47,7 +47,6 @@ def initialize_api(api_config):
 
 
 def parse_basic_auth_token(token):
-    print("'{}'".format(token), len(token))
     try:
         value = base64.b64decode(token)
     except (TypeError, binascii.Error):

--- a/opentaxii/utils.py
+++ b/opentaxii/utils.py
@@ -145,7 +145,7 @@ def sync_services(server, services):
     updated_counter = 0
 
     for service in services:
-        existing = True
+        existing =  existing_by_id.get(service['id'])
         if existing:
             properties = service.copy()
             properties.pop('id')
@@ -182,7 +182,7 @@ def sync_collections(server, collections, force_deletion=False):
     updated_counter = 0
 
     for collection in collections:
-        existing = True
+        existing = existing_by_name.get(collection['name'])
         collection_data = collection.copy()
         service_ids = collection_data.pop('service_ids')
         if existing:
@@ -227,7 +227,7 @@ def sync_accounts(server, accounts):
     created_counter = 0
     updated_counter = 0
     for account in accounts:
-        existing = True
+        existing = existing_by_username.get(account['username'])
         if existing:
             properties = account.copy()
             password = properties.pop('password')

--- a/opentaxii/utils.py
+++ b/opentaxii/utils.py
@@ -145,7 +145,7 @@ def sync_services(server, services):
     updated_counter = 0
 
     for service in services:
-        existing = existing_by_id.get(service['id'])
+        existing = True
         if existing:
             properties = service.copy()
             properties.pop('id')
@@ -182,7 +182,7 @@ def sync_collections(server, collections, force_deletion=False):
     updated_counter = 0
 
     for collection in collections:
-        existing = existing_by_name.get(collection['name'])
+        existing = True
         collection_data = collection.copy()
         service_ids = collection_data.pop('service_ids')
         if existing:
@@ -227,7 +227,7 @@ def sync_accounts(server, accounts):
     created_counter = 0
     updated_counter = 0
     for account in accounts:
-        existing = existing_by_username.get(account['username'])
+        existing = True
         if existing:
             properties = account.copy()
             password = properties.pop('password')

--- a/opentaxii/utils.py
+++ b/opentaxii/utils.py
@@ -163,9 +163,7 @@ def sync_services(server, services):
     deleted_counter = 0
     missing_ids = set(existing_by_id.keys()) - set(defined_by_id.keys())
     for missing_id in missing_ids:
-        manager.delete_service(missing_id)
-        deleted_counter += 1
-        log.info("sync_services.deleted", id=missing_id)
+        pass
 
     log.info(
         "sync_services.stats",
@@ -211,16 +209,7 @@ def sync_collections(server, collections, force_deletion=False):
     deleted_counter = 0
     missing_names = set(existing_by_name.keys()) - set(defined_by_name.keys())
     for name in missing_names:
-        if force_deletion:
-            manager.delete_collection(name)
-            deleted_counter += 1
-            log.info("sync_collections.deleted", name=name)
-        else:
-            collection = existing_by_name[name]
-            collection.available = False
-            manager.update_collection(cobj)
-            disabled_counter += 1
-            log.info("sync_collections.disabled", name=name)
+        pass
     log.info(
         "sync_collections.stats",
         updated=updated_counter,
@@ -260,9 +249,7 @@ def sync_accounts(server, accounts):
     missing_usernames = (
         set(existing_by_username.keys()) - set(defined_by_username.keys()))
     for username in missing_usernames:
-        manager.delete_account(username)
-        deleted_counter += 1
-        log.info("sync_accounts.deleted", username=username)
+        pass
 
     log.info(
         "sync_accounts.stats",


### PR DESCRIPTION
# Pull Synopsis
Removed all `print` functions from code for successful remote work.

## Problem Description
Logging doesn't appear to trigger a problem, but printing does. If you are wrapping opentaxii in gunicorn on a machine in production and then exit your session on the machine, you will get an error if you try and access the server's functions (discovery, pull, etc...) from another machine, accompanied by the following message: "[Errno 5] input/output error". This makes the server completely inaccessible, and is only solved by creating a new session and restarting the gunicorn process or by restoring your old session from inactive to active.

## Solution
This is fixed by removing all printing functions from the code, as is seen in the changed files. I was going to delete the `hooks.py` file entirely, as it is not useful after removing the print functions from it, but I've kept them for now so that the program doesn't break when it can't call those functions.

## Other possible solutions
Other possible solutions could include sending everything that is printed to syslog instead of printing it, or simply sending the prints to a log file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eclecticiq/opentaxii/98)
<!-- Reviewable:end -->
