### PR TITLE
Adding an ability to pass additional parameters for sqlalchemy.create_engine() method

### DIFF
--- a/opentaxii/auth/sqldb/api.py
+++ b/opentaxii/auth/sqldb/api.py
@@ -28,17 +28,20 @@ class SQLDatabaseAPI(OpenTAXIIAuthAPI):
     :param bool create_tables=False: if True, tables will be created in the DB.
     :param str secret: secret string used for token generation
     :param int token_ttl_secs: TTL for JWT token, in seconds.
+    :param engine_parameters=None: if defined, these arguments would be passed to sqlalchemy.create_engine
     """
     def __init__(
             self,
             db_connection,
             create_tables=False,
             secret=None,
-            token_ttl_secs=None):
+            token_ttl_secs=None,
+            **engine_parameters):
 
         self.db = SQLAlchemyDB(
             db_connection, Base, session_options={
-                'autocommit': False, 'autoflush': True})
+                'autocommit': False, 'autoflush': True},
+            **engine_parameters)
         if create_tables:
             self.db.create_all_tables()
         if not secret:

--- a/opentaxii/persistence/sqldb/api.py
+++ b/opentaxii/persistence/sqldb/api.py
@@ -32,14 +32,16 @@ class SQLDatabaseAPI(OpenTAXIIPersistenceAPI):
                           to :func:`~sqlalchemy.engine.create_engine` method.
 
     :param bool create_tables=False: if True, tables will be created in the DB.
+
+    :param engine_parameters=None: if defined, these arguments would be passed to sqlalchemy.create_engine
     """
 
-    def __init__(self, db_connection, create_tables=False):
+    def __init__(self, db_connection, create_tables=False, **engine_parameters):
 
         self.db = SQLAlchemyDB(
             db_connection, Base, session_options={
                 'autocommit': False, 'autoflush': True,
-            })
+            }, **engine_parameters)
         if create_tables:
             self.db.create_all_tables()
 

--- a/opentaxii/sqldb_helper.py
+++ b/opentaxii/sqldb_helper.py
@@ -24,9 +24,9 @@ class SQLAlchemyDB(object):
     Allows the code to use a session bind to Flask context.
     '''
 
-    def __init__(self, db_connection, base_model, session_options=None):
+    def __init__(self, db_connection, base_model, session_options=None, **kwargs):
 
-        self.engine = engine.create_engine(db_connection, convert_unicode=True)
+        self.engine = engine.create_engine(db_connection, convert_unicode=True, **kwargs)
 
         self.Query = orm.Query
         self.session = self.create_scoped_session(session_options)


### PR DESCRIPTION
There is an issue #116 about that MySQL server closes the connections time to time.
[Reading the documentation](https://docs.sqlalchemy.org/en/latest/faq/connections.html) to SQLAlchemy I found out that there is `create_engine.pool_recycle` setting is available in order to deal with this.

> MySQL features an automatic connection close behavior, for connections that have been idle for a fixed period of time, defaulting to eight hours. To circumvent having this issue, use the `create_engine.pool_recycle` option which ensures that a connection will be discarded and replaced with a new one if it has been present in the pool for a fixed number of seconds

OpenTAXII does not allow to set this (and another options) up, so I propose to extend several classes and methods in order to be able to do so by specifying the additional parameters in settings.yml file. If no additional parameters are present (like the default config is being used) - everything remains the same.