### PR TITLE
fix flaky tests

### DIFF
--- a/tests/services/test_inbox.py
+++ b/tests/services/test_inbox.py
@@ -62,11 +62,13 @@ def prepare_server(server, services):
             if coll.name not in names:
                 coll = server.persistence.create_collection(coll)
                 names.add(coll.name)
+                service_ids = [service]
             else:
                 coll = DataCollection.query.filter_by(name=coll.name).one()
+                service_ids = {s.id for s in coll.services} | {service}
 
             server.persistence.set_collection_services(
-                coll.id, service_ids=[service])
+                coll.id, service_ids=service_ids)
 
 
 @pytest.mark.parametrize("https", [True, False])


### PR DESCRIPTION
when a collection is part of more than 1 service, the collection's
services would be overwritten instead of added.

weirdly, this only seemed to cause issues in python 3.5. I have no idea
why the tests aren't flaky in other python versions.