### PR TITLE
Add lxml to requirements, require 4.3.1 or newer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pytz>=2017.2
 libtaxii>=1.1.111
+lxml>=4.3.1
 pyyaml>=3.11
 flask>=0.10.1
 sqlalchemy>=1.1.2


### PR DESCRIPTION
This will not work until 4.3.1 is released: https://pypi.org/project/lxml/#history

It includes this bugfix which we want: https://bugs.launchpad.net/lxml/+bug/1814522