### PR TITLE
release version 0.1.11

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,13 @@
 Changelog
 =========
 
-0.1.11 (TBD)
+0.1.11 (2018-02-13)
 ------------
 * Make JSON logging consistent when the application is run via Gunicorn.
+* Set `acceptable_destination` key in status details instead of extended headers
+* Allow passing `engine_parameters` to `SQLDatabaseAPI` for those who want to customize SQLAlchemy engine parameters.
+* Require recent version of `lxml` for security reasons.
+* Various test and Docker infrastructure improvements.
 
 0.1.10 (2018-06-03)
 -------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import datetime
 import sys
 import os
 
@@ -45,7 +46,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'OpenTAXII'
-copyright = u'2016, EclecticIQ'
+copyright = u'2016-%s, EclecticIQ' % datetime.date.now().year
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/opentaxii/_version.py
+++ b/opentaxii/_version.py
@@ -3,4 +3,4 @@ Version module.
 This module defines the package version for use in __init__.py and setup.py.
 """
 
-__version__ = '0.1.11a2'
+__version__ = '0.1.11'


### PR DESCRIPTION
- Updated `CHANGES.rst`
- Bumped version in `opentaxii/_version.py`
- Make copyright year in docs dynamic