### PR TITLE
Fix PyLint W0231

### DIFF
--- a/opentaxii/config.py
+++ b/opentaxii/config.py
@@ -37,4 +37,4 @@ class ServerConfig(dict):
             config_paths, ac_parser='yaml',
             ignore_missing=False, ac_merge=anyconfig.MS_REPLACE)
 
-        self.update(options)
+        super().__init__(options)

--- a/opentaxii/config.py
+++ b/opentaxii/config.py
@@ -37,4 +37,4 @@ class ServerConfig(dict):
             config_paths, ac_parser='yaml',
             ignore_missing=False, ac_merge=anyconfig.MS_REPLACE)
 
-        super().__init__(options)
+        super(ServerConfig, self).__init__(options)


### PR DESCRIPTION
> `__init__` method from base class %r is not called