### PR TITLE
Fix PyLint R1705

### DIFF
--- a/opentaxii/middleware.py
+++ b/opentaxii/middleware.py
@@ -81,9 +81,10 @@ def _server_wrapper(server):
 
                 if not service.available:
                     raise_failure("The service is not available")
+
                 if request.method == 'POST':
                     return _process_with_service(service)
-                elif request.method == 'OPTIONS':
+                if request.method == 'OPTIONS':
                     return _process_options_request(service)
         finally:
             release_context()

--- a/opentaxii/taxii/http.py
+++ b/opentaxii/taxii/http.py
@@ -67,18 +67,16 @@ def get_content_type(headers):
 def get_http_headers(version, is_secure):
 
     taxii_11 = [VID_TAXII_XML_11, VID_TAXII_SERVICES_11]
-    taxii_10 = [VID_TAXII_XML_10, VID_TAXII_SERVICES_10]
-
     if version in taxii_11:
         if is_secure:
             return TAXII_11_HTTPS_Headers
-        else:
-            return TAXII_11_HTTP_Headers
-    elif version in taxii_10:
+        return TAXII_11_HTTP_Headers
+
+    taxii_10 = [VID_TAXII_XML_10, VID_TAXII_SERVICES_10]
+    if version in taxii_10:
         if is_secure:
             return TAXII_10_HTTPS_Headers
-        else:
-            return TAXII_10_HTTP_Headers
+        return TAXII_10_HTTP_Headers
 
     # FIXME: should raise a custom error
     raise ValueError(

--- a/opentaxii/taxii/services/handlers/collection_information_request_handlers.py
+++ b/opentaxii/taxii/services/handlers/collection_information_request_handlers.py
@@ -59,10 +59,9 @@ class CollectionInformationRequestHandler(BaseMessageHandler):
         if isinstance(request, tm10.FeedInformationRequest):
             return FeedInformationRequest10Handler.handle_message(
                 service, request)
-        elif isinstance(request, tm11.CollectionInformationRequest):
+        if isinstance(request, tm11.CollectionInformationRequest):
             return CollectionInformationRequest11Handler.handle_message(
                 service, request)
-        else:
-            raise_failure(
-                "TAXII Message not supported by message handler",
-                request.message_id)
+        raise_failure(
+            "TAXII Message not supported by message handler",
+            request.message_id)

--- a/opentaxii/taxii/services/handlers/discovery_request_handlers.py
+++ b/opentaxii/taxii/services/handlers/discovery_request_handlers.py
@@ -48,8 +48,9 @@ class DiscoveryRequestHandler(BaseMessageHandler):
 
         if isinstance(request, tm10.DiscoveryRequest):
             return DiscoveryRequest10Handler.handle_message(service, request)
-        elif isinstance(request, tm11.DiscoveryRequest):
+        if isinstance(request, tm11.DiscoveryRequest):
             return DiscoveryRequest11Handler.handle_message(service, request)
-        else:
-            raise_failure("TAXII Message not supported by message handler",
-                          request.message_id)
+        raise_failure(
+            "TAXII Message not supported by message handler",
+            request.message_id,
+        )

--- a/opentaxii/taxii/services/handlers/inbox_message_handlers.py
+++ b/opentaxii/taxii/services/handlers/inbox_message_handlers.py
@@ -119,8 +119,9 @@ class InboxMessageHandler(BaseMessageHandler):
     def handle_message(cls, service, request):
         if isinstance(request, tm10.InboxMessage):
             return InboxMessage10Handler.handle_message(service, request)
-        elif isinstance(request, tm11.InboxMessage):
+        if isinstance(request, tm11.InboxMessage):
             return InboxMessage11Handler.handle_message(service, request)
-        else:
-            raise_failure("TAXII Message not supported by message handler",
-                          request.message_id)
+        raise_failure(
+            "TAXII Message not supported by message handler",
+            request.message_id,
+        )

--- a/opentaxii/taxii/services/handlers/poll_fulfilment_request_handlers.py
+++ b/opentaxii/taxii/services/handlers/poll_fulfilment_request_handlers.py
@@ -56,8 +56,9 @@ class PollFulfilmentRequestHandler(BaseMessageHandler):
     @classmethod
     def handle_message(cls, service, request):
         if isinstance(request, tm11.PollFulfillmentRequest):
-            return PollFulfilmentRequest11Handler.handle_message(service,
-                                                                 request)
-        else:
-            raise_failure("TAXII Message not supported by message handler",
-                          request.message_id)
+            return PollFulfilmentRequest11Handler.handle_message(
+                service=service,
+                request=request,
+            )
+        raise_failure("TAXII Message not supported by message handler",
+                      request.message_id)

--- a/opentaxii/taxii/services/handlers/poll_request_handlers.py
+++ b/opentaxii/taxii/services/handlers/poll_request_handlers.py
@@ -298,8 +298,9 @@ class PollRequestHandler(BaseMessageHandler):
     def handle_message(cls, service, request):
         if isinstance(request, tm10.PollRequest):
             return PollRequest10Handler.handle_message(service, request)
-        elif isinstance(request, tm11.PollRequest):
+        if isinstance(request, tm11.PollRequest):
             return PollRequest11Handler.handle_message(service, request)
-        else:
-            raise_failure("TAXII Message not supported by message handler",
-                          request.message_id)
+        raise_failure(
+            "TAXII Message not supported by message handler",
+            request.message_id,
+        )

--- a/opentaxii/taxii/services/handlers/subscription_request_handlers.py
+++ b/opentaxii/taxii/services/handlers/subscription_request_handlers.py
@@ -72,21 +72,19 @@ def action_unsubscribe(request, service, subscription, **kwargs):
     if subscription:
         subscription.status = SubscriptionEntity.UNSUBSCRIBED
         return service.update_subscription(subscription)
-    else:
-        # Spec says that unsubscribe should be successful even
-        # if subscription doesn't exist
-        return SubscriptionEntity(
-            collection_id=None,
-            service_id=service.id,
-            subscription_id=request.subscription_id,
-            status=SubscriptionEntity.UNSUBSCRIBED)
+    # Spec says that unsubscribe should be successful even
+    # if subscription doesn't exist
+    return SubscriptionEntity(
+        collection_id=None,
+        service_id=service.id,
+        subscription_id=request.subscription_id,
+        status=SubscriptionEntity.UNSUBSCRIBED)
 
 
 def action_status(service, subscription, **kwargs):
     if subscription:
         return subscription
-    else:
-        return service.get_subscriptions()
+    return service.get_subscriptions()
 
 
 def action_pause(service, subscription, **kwargs):
@@ -276,10 +274,9 @@ class SubscriptionRequestHandler(BaseMessageHandler):
         if isinstance(request, tm10.ManageFeedSubscriptionRequest):
             return SubscriptionRequest10Handler.handle_message(
                 service, request)
-        elif isinstance(request, tm11.ManageCollectionSubscriptionRequest):
+        if isinstance(request, tm11.ManageCollectionSubscriptionRequest):
             return SubscriptionRequest11Handler.handle_message(
                 service, request)
-        else:
-            raise_failure(
-                "TAXII Message not supported by message handler",
-                request.message_id)
+        raise_failure(
+            "TAXII Message not supported by message handler",
+            request.message_id)

--- a/opentaxii/utils.py
+++ b/opentaxii/utils.py
@@ -18,11 +18,9 @@ log = structlog.getLogger(__name__)
 
 def get_path_and_address(domain, address):
     parsed = urllib.parse.urlparse(address)
-
     if parsed.scheme:
         return None, address
-    else:
-        return address, domain + address
+    return address, domain + address
 
 
 def import_class(module_class_name):


### PR DESCRIPTION
> R1705: Unnecessary "else" after "return" (no-else-return)

Also, some functions had unexpected behavior if the TAXII version is not 10 or 11. I've added `raise ValueError('invalid version')`. It will help us to incrementally migrate on TAXII 2.0.