### PR TITLE
allow to specify status for UNAUTHTORIZED

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -31,6 +31,7 @@ Default configuration file looks like this:
     xml_parser_supports_huge_tree: yes
     count_blocks_in_poll_responses: no
     return_server_error_details: no
+    unauthorized_status: UNAUTHORIZED
 
     persistence_api:
       class: opentaxii.persistence.sqldb.SQLDatabaseAPI
@@ -49,8 +50,8 @@ Default configuration file looks like this:
       opentaxii: info
       root: info
 
-    hooks: 
-    
+    hooks:
+
 .. note::
   OpenTAXII uses a SQLite Database by default wich is intended only when running OpenTAXII in a development environment. Please use different SQL DB backend for running in a production environment.
 
@@ -82,6 +83,7 @@ Properties
     - ``xml_parser_supports_huge_tree`` — enable/disable security restrictions in `lxml <http://lxml.de/>`_ library to allow support for very deep trees and very long text content. If this is disabled, OpenTAXII will not be able to parse TAXII messages with content blocks larger than roughly 10MB.
     - ``count_blocks_in_poll_responses`` — enable/disable total count in TAXII Poll responses. It is disabled by default since ``count`` operation might be `very slow <https://wiki.postgresql.org/wiki/Slow_Counting>`_ in some SQL DBs.
     - ``return_server_error_details`` — allow OpenTAXII to return error details in error-status TAXII response.
+    - ``unauthorized_status`` — TAXII status type for authorization error. "UNAUTHORIZED" by default.
     - ``persistence_api`` — configuration properties for Persistence API implementation.
     - ``auth_api`` — configuration properties for Authentication API implementation.
     - ``logging`` — logging configuration.
@@ -97,8 +99,8 @@ To pass custom configuration to OpenTAXII server, specify an absolute path to yo
 configuration file in environment variable ``OPENTAXII_CONFIG``.::
 
 	$ export OPENTAXII_CONFIG=/path/to/configuration/file.yml
-	
-	
+
+
 This configuration file may fully or partially override default settings.
 
 Example custom configuration:
@@ -137,11 +139,11 @@ Services, collections and accounts
 Services, collections and accounts can be created with CLI command ``opentaxii-sync-data`` or with custom code talking to a specific Persistent API implementation/backend.
 
 Step 1
------- 
+------
 Create YAML file with collections/services/accounts configuration. See provided example from `OpenTAXII git repo <https://github.com/eclecticiq/OpenTAXII>`_ — file :github-file:`examples/data-configuration.yml <examples/data-configuration.yml>` that contains:
 
 Services:
-    * 2 Inbox Services (with ids ``inbox_a`` and ``inbox_b``), 
+    * 2 Inbox Services (with ids ``inbox_a`` and ``inbox_b``),
     * 1 Discovery Service (with id ``discovery_a``),
     * 1 Collection Management Service (with id ``collection_management_a``),
     * 1 Poll Service (with id ``poll_a``).

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -83,7 +83,7 @@ Properties
     - ``xml_parser_supports_huge_tree`` — enable/disable security restrictions in `lxml <http://lxml.de/>`_ library to allow support for very deep trees and very long text content. If this is disabled, OpenTAXII will not be able to parse TAXII messages with content blocks larger than roughly 10MB.
     - ``count_blocks_in_poll_responses`` — enable/disable total count in TAXII Poll responses. It is disabled by default since ``count`` operation might be `very slow <https://wiki.postgresql.org/wiki/Slow_Counting>`_ in some SQL DBs.
     - ``return_server_error_details`` — allow OpenTAXII to return error details in error-status TAXII response.
-    - ``unauthorized_status`` — TAXII status type for authorization error. "UNAUTHORIZED" by default.
+    - ``unauthorized_status`` — TAXII status type for authorization error. "UNAUTHORIZED" by default. see `libtaxii.constants.ST_TYPES_11 <https://libtaxii.readthedocs.io/en/stable/api/constants.html#libtaxii.constants.ST_TYPES_11>`_ for the list of available values.
     - ``persistence_api`` — configuration properties for Persistence API implementation.
     - ``auth_api`` — configuration properties for Authentication API implementation.
     - ``logging`` — logging configuration.

--- a/opentaxii/config.py
+++ b/opentaxii/config.py
@@ -1,5 +1,6 @@
 import os
 import anyconfig
+from libtaxii.constants import ST_TYPES_10, ST_TYPES_11
 
 current_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -36,5 +37,8 @@ class ServerConfig(dict):
         options = anyconfig.load(
             config_paths, ac_parser='yaml',
             ignore_missing=False, ac_merge=anyconfig.MS_REPLACE)
+
+        if options['unauthorized_status'] not in ST_TYPES_10 + ST_TYPES_11:
+            raise ValueError('invalid value for unauthorized_status field')
 
         self.update(options)

--- a/opentaxii/defaults.yml
+++ b/opentaxii/defaults.yml
@@ -7,6 +7,7 @@ save_raw_inbox_messages: yes
 xml_parser_supports_huge_tree: yes
 count_blocks_in_poll_responses: no
 return_server_error_details: no
+unauthorized_status: UNAUTHORIZED
 
 persistence_api:
   class: opentaxii.persistence.sqldb.SQLDatabaseAPI
@@ -28,4 +29,3 @@ logging:
   root: info
 
 hooks:
-

--- a/opentaxii/middleware.py
+++ b/opentaxii/middleware.py
@@ -73,7 +73,9 @@ def _server_wrapper(server):
             if service:
                 if (service.authentication_required
                         and context.account is None):
-                    raise UnauthorizedException()
+                    raise UnauthorizedException(
+                        status_type=server.config['unauthorized_status'],
+                    )
 
                 if not service.authentication_required:
                     # if service is not protected, full access
@@ -111,7 +113,9 @@ def _authenticate(server, headers):
     if auth_type == 'basic':
 
         if not server.is_basic_auth_supported():
-            raise UnauthorizedException()
+            raise UnauthorizedException(
+                status_type=server.config['unauthorized_status'],
+            )
 
         try:
             username, password = parse_basic_auth_token(raw_token)
@@ -125,15 +129,21 @@ def _authenticate(server, headers):
     elif auth_type == 'bearer':
         token = raw_token
     else:
-        raise UnauthorizedException()
+        raise UnauthorizedException(
+            status_type=server.config['unauthorized_status'],
+        )
 
     if not token:
-        raise UnauthorizedException()
+        raise UnauthorizedException(
+            status_type=server.config['unauthorized_status'],
+        )
 
     account = server.auth.get_account(token)
 
     if not account:
-        raise UnauthorizedException()
+        raise UnauthorizedException(
+            status_type=server.config['unauthorized_status'],
+        )
 
     return account
 

--- a/opentaxii/taxii/exceptions.py
+++ b/opentaxii/taxii/exceptions.py
@@ -36,8 +36,8 @@ class FailureStatus(StatusMessageException):
 
 class UnauthorizedStatus(StatusMessageException):
 
-    def __init__(self, **kwargs):
-        super(UnauthorizedStatus, self).__init__(ST_UNAUTHORIZED, **kwargs)
+    def __init__(self, status_type=ST_UNAUTHORIZED, **kwargs):
+        super(UnauthorizedStatus, self).__init__(status_type=status_type, **kwargs)
 
 
 def raise_failure(message, in_response_to='0'):

--- a/opentaxii/taxii/exceptions.py
+++ b/opentaxii/taxii/exceptions.py
@@ -37,7 +37,9 @@ class FailureStatus(StatusMessageException):
 class UnauthorizedStatus(StatusMessageException):
 
     def __init__(self, status_type=ST_UNAUTHORIZED, **kwargs):
-        super(UnauthorizedStatus, self).__init__(status_type=status_type, **kwargs)
+        super(UnauthorizedStatus, self).__init__(
+            status_type=status_type.upper(),
+            **kwargs)
 
 
 def raise_failure(message, in_response_to='0'):

--- a/opentaxii/taxii/services/abstract.py
+++ b/opentaxii/taxii/services/abstract.py
@@ -5,7 +5,7 @@ from libtaxii.constants import (
     VID_TAXII_XML_10, VID_TAXII_XML_11
 )
 
-from ..exceptions import StatusMessageException, raise_failure
+from ..exceptions import raise_failure
 from ..bindings import PROTOCOL_TO_SCHEME
 from ..converters import service_to_service_instances
 
@@ -79,11 +79,7 @@ class TAXIIService(object):
         handler.validate_headers(headers, in_response_to=message.message_id)
         handler.verify_message_is_supported(message)
 
-        try:
-            response_message = handler.handle_message(self, message)
-        except StatusMessageException:
-            raise
-
+        response_message = handler.handle_message(self, message)
         if not response_message:
             raise_failure(
                 "The message handler {} did not return a TAXII Message"


### PR DESCRIPTION
Fix #18 with backward compatibility. Allow specifying alternative TAXII status type instead of "UNAUTHTORIZED". By default, use unauthorized how it recommend by spec (5.1 HTTP Responses as TAXII Status Messages).