### PR TITLE
Env vars configuration

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -91,9 +91,6 @@ cp -f $tmpConfig /opentaxii.yml
 # Lets see if there is an override
 [ -f /input/opentaxii.yml ] && cp -f /input/opentaxii.yml /opentaxii.yml
 
-echo "Using config: "
-cat /opentaxii.yml
-
 # Wait for port to become available in case of SQL
 [ "$DATABASE_HOST" ] && wait_for_port $DATABASE_HOST ${DATABASE_PORT-5432}
 [ "$AUTH_DATABASE_HOST" ] && wait_for_port $AUTH_DATABASE_HOST ${AUTH_DATABASE_PORT-5432}

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -132,6 +132,18 @@ The built-in implementation of the Persistence and Authentication APIs support S
 
 OpenTAXII CLI tools are implemented to call corresponding API methods and support any API implementation.
 
+Environment variables configuration
+===================================
+
+You can (re)define any configuration option with environment variables. Start variable name with ``OPENTAXII_``. Use ``__`` to separate parts of the config path. Use uppercase. Specify values in YAML syntax.
+
+.. code-block:: bash
+    export OPENTAXII_DOMAIN='taxii.mydomain.com'
+    export OPENTAXII_SUPPORT_BASIC_AUTH='no'
+    export OPENTAXII__PERSISTENCE_API__CLASS='mypackage.opentaxii.CustomPersistenceAPI'
+    export OPENTAXII__AUTH_API__PARAMETERS__SECRET='aueHenjitweridUcviapEbsJocdiDrelHonsyorl'
+
+Environment variables applied after all other configs and can be used to redefine any option.
 
 Services, collections and accounts
 ==================================

--- a/opentaxii/cli/persistence.py
+++ b/opentaxii/cli/persistence.py
@@ -1,6 +1,6 @@
-import anyconfig
 import argparse
 import structlog
+import yaml
 
 from opentaxii.entities import Account
 from opentaxii.cli import app
@@ -26,7 +26,8 @@ def sync_data_configuration():
               "if collection is not defined in configuration file"),
         required=False)
     args = parser.parse_args()
-    config = anyconfig.load(args.config, forced_type="yaml")
+    with open(args.config) as stream:
+        config = yaml.safe_load(stream=stream)
 
     with app.app_context():
         # run as admin with full access

--- a/opentaxii/config.py
+++ b/opentaxii/config.py
@@ -33,13 +33,16 @@ class ServerConfig(dict):
 
     def __init__(self, optional_env_var=CONFIG_ENV_VAR, extra_configs=None):
 
+        # 4. default config
         configs = [DEFAULT_CONFIG]
+        # 3. explicit configs
         configs.extend(extra_configs or [])
-        configs.append(self._get_env_config())
-
+        # 2. config from OPENTAXII_CONFIG env var path
         env_var_path = os.environ.get(optional_env_var)
         if env_var_path:
             configs.append(env_var_path)
+        # 1. config built from env vars
+        configs.append(self._get_env_config())
 
         options = self._load_configs(*configs)
         if options['unauthorized_status'] not in ST_TYPES_10 + ST_TYPES_11:

--- a/opentaxii/config.py
+++ b/opentaxii/config.py
@@ -54,12 +54,12 @@ class ServerConfig(dict):
         super(ServerConfig, self).__init__(options)
 
     @staticmethod
-    def _get_env_config(self, env=os.environ):
+    def _get_env_config(env=os.environ):
         result = _infinite_dict()
         for key, value in env.items():
             if not key.startswith(ENV_VAR_PREFIX):
                 continue
-            key = key[len(ENV_VAR_PREFIX):]
+            key = key[len(ENV_VAR_PREFIX):].lower()
             value = yaml.loads(value)
 
             container = result
@@ -78,16 +78,5 @@ class ServerConfig(dict):
             if not isinstance(config, dict):
                 with open(config) as stream:
                     config = yaml.safe_load(stream=stream)
-            result = cls._merge_configs(result, config)
-        return result
-
-    @classmethod
-    def _merge_configs(cls, *configs):
-        result = dict()
-        for config in configs:
-            for k, v in config.items():
-                if isinstance(v, dict) and k in result:
-                    result[k] = cls._merge_configs(result[k], v)
-                else:
-                    result[k] = v
+            result.update(config)
         return result

--- a/opentaxii/config.py
+++ b/opentaxii/config.py
@@ -34,8 +34,8 @@ class ServerConfig(dict):
     def __init__(self, optional_env_var=CONFIG_ENV_VAR, extra_configs=None):
 
         configs = [DEFAULT_CONFIG]
-        configs.append(self._get_env_config())
         configs.extend(extra_configs or [])
+        configs.append(self._get_env_config())
 
         env_var_path = os.environ.get(optional_env_var)
         if env_var_path:

--- a/opentaxii/config.py
+++ b/opentaxii/config.py
@@ -5,12 +5,6 @@ import yaml
 from libtaxii.constants import ST_TYPES_10, ST_TYPES_11
 
 
-try:
-    from functools import reduce
-except ImportError:
-    pass
-
-
 current_dir = os.path.dirname(os.path.realpath(__file__))
 
 ENV_VAR_PREFIX = 'OPENTAXII_'
@@ -59,8 +53,8 @@ class ServerConfig(dict):
         for key, value in env.items():
             if not key.startswith(ENV_VAR_PREFIX):
                 continue
-            key = key[len(ENV_VAR_PREFIX):].lower()
-            value = yaml.loads(value)
+            key = key[len(ENV_VAR_PREFIX):].lstrip('_').lower()
+            value = yaml.safe_load(value)
 
             container = result
             parts = key.split('__')

--- a/opentaxii/config.py
+++ b/opentaxii/config.py
@@ -1,12 +1,26 @@
 import os
-import anyconfig
+from collections import defaultdict
+
+import yaml
 from libtaxii.constants import ST_TYPES_10, ST_TYPES_11
+
+
+try:
+    from functools import reduce
+except ImportError:
+    pass
+
 
 current_dir = os.path.dirname(os.path.realpath(__file__))
 
+ENV_VAR_PREFIX = 'OPENTAXII_'
 CONFIG_ENV_VAR = 'OPENTAXII_CONFIG'
 DEFAULT_CONFIG_NAME = 'defaults.yml'
 DEFAULT_CONFIG = os.path.join(current_dir, DEFAULT_CONFIG_NAME)
+
+
+def _infinite_dict():
+    return defaultdict(_infinite_dict)
 
 
 class ServerConfig(dict):
@@ -25,20 +39,55 @@ class ServerConfig(dict):
 
     def __init__(self, optional_env_var=CONFIG_ENV_VAR, extra_configs=None):
 
-        config_paths = [DEFAULT_CONFIG]
-
-        if extra_configs:
-            config_paths.extend(extra_configs)
+        configs = [DEFAULT_CONFIG]
+        configs.append(self._get_env_config())
+        configs.extend(extra_configs or [])
 
         env_var_path = os.environ.get(optional_env_var)
         if env_var_path:
-            config_paths.append(env_var_path)
+            configs.append(env_var_path)
 
-        options = anyconfig.load(
-            config_paths, ac_parser='yaml',
-            ignore_missing=False, ac_merge=anyconfig.MS_REPLACE)
-
+        options = self._load_configs(*configs)
         if options['unauthorized_status'] not in ST_TYPES_10 + ST_TYPES_11:
             raise ValueError('invalid value for unauthorized_status field')
 
         super(ServerConfig, self).__init__(options)
+
+    @staticmethod
+    def _get_env_config(self, env=os.environ):
+        result = _infinite_dict()
+        for key, value in env.items():
+            if not key.startswith(ENV_VAR_PREFIX):
+                continue
+            key = key[len(ENV_VAR_PREFIX):]
+            value = yaml.loads(value)
+
+            container = result
+            parts = key.split('__')
+            for part in parts[:-1]:
+                container = container[part]
+            container[parts[-1]] = value
+
+        return dict(result)
+
+    @classmethod
+    def _load_configs(cls, *configs):
+        result = dict()
+        for config in configs:
+            # read content from path-like object
+            if not isinstance(config, dict):
+                with open(config) as stream:
+                    config = yaml.safe_load(stream=stream)
+            result = cls._merge_configs(result, config)
+        return result
+
+    @classmethod
+    def _merge_configs(cls, *configs):
+        result = dict()
+        for config in configs:
+            for k, v in config.items():
+                if isinstance(v, dict) and k in result:
+                    result[k] = cls._merge_configs(result[k], v)
+                else:
+                    result[k] = v
+        return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ flask>=0.10.1
 sqlalchemy>=1.1.2
 structlog>=18.1.0
 blinker>=1.4
-anyconfig>=0.9.3
 pyjwt>=1.4.0
 six>=1.10.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,10 +44,11 @@ def test_env_vars_config():
         OPENTAXII_DOMAIN='hostname:1337',
         OPENTAXII__SUPPORT_BASIC_AUTH='yes',
         OPENTAXII__PERSISTENCE_API__CLASS='something.Else',
+        OPENTAXII__PERSISTENCE_API__OTHER='1',
     )
     expected = dict(
         domain='hostname:1337',
         support_basic_auth=True,
-        persistence_api={'class': 'something.Else'},
+        persistence_api={'class': 'something.Else', 'other': 1},
     )
     assert ServerConfig._get_env_config(env=vars) == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,3 +37,17 @@ def test_custom_config_file(config_file_name):
 
     assert config['auth_api']['class'] == 'other.test.AuthClass'
     assert config['auth_api']['parameters'] == {'c': 3}
+
+
+def test_env_vars_config():
+    vars = dict(
+        OPENTAXII_DOMAIN='hostname:1337',
+        OPENTAXII__SUPPORT_BASIC_AUTH='yes',
+        OPENTAXII__PERSISTENCE_API__CLASS='something.Else',
+    )
+    expected = dict(
+        domain='hostname:1337',
+        support_basic_auth=True,
+        persistence_api={'class': 'something.Else'},
+    )
+    assert ServerConfig._get_env_config(env=vars) == expected


### PR DESCRIPTION
1. Allow to configure OpenTAXII with env vars
1. Drop `anyconfig` dependency. Fewer deps for OSS is always good.
1. Drop showing config in docker logs

Close #154 