### PR TITLE
Upgrade gunicorn

### DIFF
--- a/opentaxii/http.py
+++ b/opentaxii/http.py
@@ -14,6 +14,7 @@ from .utils import configure_logging
 logconfig_dict = {
     'version': 1,
     'disable_existing_loggers': False,
+    'root': {},
     'loggers': {
         'gunicorn.error': {
             'level': 'INFO',

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,2 +1,2 @@
-gunicorn==19.9.0
+gunicorn==20.0.4
 psycopg2-binary==2.7.6.1


### PR DESCRIPTION
1. Upgrade Gunicorn to the version used in the EclecticIQ platform.
2. Rewrite root logger. New gunicorn sets the root logger (before it was missed accidentally): https://github.com/benoitc/gunicorn/pull/1958. We should rewrite it to force using the JSON handler.