### PR TITLE
Fix decoding string token

### DIFF
--- a/opentaxii/management.py
+++ b/opentaxii/management.py
@@ -20,7 +20,7 @@ def auth():
     if not token:
         abort(401)
 
-    return jsonify(token=token.decode('utf-8'))
+    return jsonify(token=token)
 
 
 @management.route('/health', methods=['GET'])


### PR DESCRIPTION
the server throws unauthorized error every time a valid user tries to access it, it's trying to decode the token (treating it as bytes instead of str) which is not the case here