### PR TITLE
Get visibility into docstring coverage

### DIFF
--- a/.github/workflows/interrogate.yml
+++ b/.github/workflows/interrogate.yml
@@ -1,0 +1,17 @@
+name: Check docstring coverage
+
+on:
+  - pull_request
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install interrogate
+      run: pip install -r requirements-interrogate.txt
+    - name: Run interrogate
+      run: interrogate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.interrogate]
+ignore-init-method = true
+ignore-init-module = true
+ignore-magic = true
+ignore-module = true
+ignore-nested-functions = true
+ignore-nested-classes = true
+ignore-private = true
+ignore-semiprivate = true
+omit-covered-files = true
+verbose = 2
+fail-under = 32.7
+exclude = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-pythonpath
 flake8
 ipdb
 git+https://github.com/eclecticiq/sqla-graphs.git@py3
+-r requirements-interrogate.txt

--- a/requirements-interrogate.txt
+++ b/requirements-interrogate.txt
@@ -1,0 +1,1 @@
+interrogate>=1.5.0


### PR DESCRIPTION
## Short description

Get additional visiblity into status of docs

## Motivation

Docstrings are good for developers. We could use significantly more (and better, but that's hard to measure). This MR is a small attempt at introducing some visibility into the status of docstrings.

## Implementation

Uses [interrogate](https://interrogate.readthedocs.io/en/latest/) in a job coverage doesn't drop below the current value. Current coverage is 32.7%, with a setting that ignores coverage for a bunch of things. As time passes and docs improve, we might tighten the settings or increase the goal.