### PR TITLE
Make sure werkzeug <2.1 and >=2.1 work correctly with auth

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.2.4 (2022-04-13)
+------------------
+* Make sure werkzeug <2.1 and >=2.1 work correctly with auth system
+
 0.2.3 (2021-12-22)
 ------------------
 * Fix bug in multithreaded use of sqlite (`#210 <https://github.com/eclecticiq/OpenTAXII/issues/114>`_ thanks `@rohits144 <https://github.com/rohits144>`_ for the report)

--- a/opentaxii/management.py
+++ b/opentaxii/management.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify, abort
+from flask import Blueprint, abort, jsonify, request
 
 from .local import context
 
@@ -7,7 +7,7 @@ management = Blueprint('management', __name__)
 
 @management.route('/auth', methods=['POST'])
 def auth():
-    data = request.get_json() or request.form
+    data = request.get_json(silent=True) or request.form
 
     username = data.get('username')
     password = data.get('password')

--- a/opentaxii/sqldb_helper.py
+++ b/opentaxii/sqldb_helper.py
@@ -1,4 +1,5 @@
-from flask import _app_ctx_stack
+from threading import get_ident
+
 from sqlalchemy import engine, orm
 from sqlalchemy.orm.exc import UnmappedClassError
 
@@ -44,11 +45,10 @@ class SQLAlchemyDB(object):
 
         options = options or {}
 
-        scopefunc = _app_ctx_stack.__ident_func__
         options.setdefault('query_cls', self.Query)
 
         return orm.scoped_session(
-            self.create_session(options), scopefunc=scopefunc)
+            self.create_session(options), scopefunc=get_ident)
 
     def create_session(self, options):
         return orm.sessionmaker(bind=self.engine, **options)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py{36,37,38,39,py3,ston}-sqlalchemy{13,14}-{sqlite,mysql,mariadb,postgres}, flake8
+envlist = py{36,37,38,39,py3,ston}-sqlalchemy{13,14}-werkzeug{lt21,gte21}-{sqlite,mysql,mariadb,postgres}, flake8
 
 [gh-actions]
 python =
@@ -20,6 +20,8 @@ deps =
     postgres-pypy3: -rrequirements-dev-postgres-pypy.txt
     sqlalchemy13: sqlalchemy>=1.3,<1.4
     sqlalchemy14: sqlalchemy>=1.4,<1.5
+    werkzeuglt21: werkzeug<2.1
+    werkzeuggte21: werkzeug>=2.1
 setenv =
     LC_ALL=en_US.UTF-8
     sqlite: DBTYPE=sqlite

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 skipsdist = True
-envlist = py{36,37,38,39,py3,ston}-sqlalchemy{13,14}-werkzeug{lt21,gte21}-{sqlite,mysql,mariadb,postgres}, flake8
+envlist = py36-sqlalchemy{13,14}-werkzeuglt21-{sqlite,mysql,mariadb,postgres},
+          py{37,38,39,py3,ston}-sqlalchemy{13,14}-werkzeug{lt21,gte21}-{sqlite,mysql,mariadb,postgres},
+          flake8
 
 [gh-actions]
 python =


### PR DESCRIPTION
[Werkzeug 2.1](https://werkzeug.palletsprojects.com/en/2.1.x/changes/#version-2-1-0) broke our auth system. It now throws an exception instead of returning `None` when being passed non-json when calling `.to_json`. We depended on the previous behaviour.

This PR adds werkzeug<2.1 and >=2.1 to the tox matrix to ensure we support both cases and fixes the code.