### PR TITLE
Move next_param handling into `OpenTAXII2PersistenceAPI`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.4.0 (2022-05-20)
+------------------
+* Move next_param handling into `OpenTAXII2PersistenceAPI`
+
 0.3.0 (2022-04-13)
 ------------------
 * Implement taxii2.1 support

--- a/opentaxii/_version.py
+++ b/opentaxii/_version.py
@@ -3,4 +3,4 @@ Version module.
 This module defines the package version for use in __init__.py and setup.py.
 """
 
-__version__ = '0.3.0'
+__version__ = '0.4.0'

--- a/opentaxii/persistence/api.py
+++ b/opentaxii/persistence/api.py
@@ -348,7 +348,7 @@ class OpenTAXII2PersistenceAPI:
         match_spec_version: Optional[List[str]] = None,
     ) -> Tuple[Optional[List[STIXObject]], bool, Optional[str]]:
         """
-        Get all versions of single object from database.
+        Get single object from database.
 
         Should return `None` when object matching object_id doesn't exist.
         """
@@ -372,4 +372,9 @@ class OpenTAXII2PersistenceAPI:
         next_kwargs: Optional[Dict] = None,
         match_spec_version: Optional[List[str]] = None,
     ) -> Tuple[List[VersionRecord], bool]:
+        """
+        Get all versions of single object from database.
+
+        Should return `None` when object matching object_id doesn't exist.
+        """
         raise NotImplementedError

--- a/opentaxii/persistence/api.py
+++ b/opentaxii/persistence/api.py
@@ -267,8 +267,29 @@ class OpenTAXII2PersistenceAPI:
 
     Stub, pending implementation.
     """
+    @staticmethod
+    def get_next_param(self, kwargs: Dict) -> str:
+        """
+        Get value for `next` based on :class:`Dict` instance.
+
+        :param :class:`Dict` kwargs: The dict to base the `next` param on
+
+        :return: The value to use as `next` param
+        :rtype: str
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def parse_next_param(next_param: str) -> Dict:
+        """
+        Parse provided `next_param` into kwargs to be used to filter stix objects.
+        """
+        raise NotImplementedError
 
     def get_api_roots(self) -> List[ApiRoot]:
+        """
+        Parse provided `next_param` into kwargs to be used to filter stix objects.
+        """
         raise NotImplementedError
 
     def get_api_root(self, api_root_id: str) -> Optional[ApiRoot]:
@@ -310,7 +331,7 @@ class OpenTAXII2PersistenceAPI:
         match_type: Optional[List[str]] = None,
         match_version: Optional[List[str]] = None,
         match_spec_version: Optional[List[str]] = None,
-    ) -> Tuple[List[STIXObject], bool]:
+    ) -> Tuple[List[STIXObject], bool, Optional[str]]:
         raise NotImplementedError
 
     def add_objects(self, api_root_id: str, collection_id: str, objects: List[Dict]) -> Tuple[Job, List[JobDetail]]:
@@ -325,7 +346,7 @@ class OpenTAXII2PersistenceAPI:
         next_kwargs: Optional[Dict] = None,
         match_version: Optional[List[str]] = None,
         match_spec_version: Optional[List[str]] = None,
-    ) -> Tuple[Optional[List[STIXObject]], bool]:
+    ) -> Tuple[Optional[List[STIXObject]], bool, Optional[str]]:
         """
         Get all versions of single object from database.
 

--- a/opentaxii/persistence/manager.py
+++ b/opentaxii/persistence/manager.py
@@ -500,7 +500,7 @@ class Taxii2PersistenceManager(BasePersistenceManager):
         match_type: Optional[List[str]] = None,
         match_version: Optional[List[str]] = None,
         match_spec_version: Optional[List[str]] = None,
-    ) -> Tuple[List[STIXObject], bool]:
+    ) -> Tuple[List[STIXObject], bool, Optional[str]]:
         collection = self.get_collection(
             api_root_id=api_root_id, collection_id_or_alias=collection_id_or_alias
         )
@@ -546,13 +546,13 @@ class Taxii2PersistenceManager(BasePersistenceManager):
         next_kwargs: Optional[Dict] = None,
         match_version: Optional[List[str]] = None,
         match_spec_version: Optional[List[str]] = None,
-    ) -> Tuple[List[STIXObject], bool]:
+    ) -> Tuple[List[STIXObject], bool, Optional[str]]:
         collection = self.get_collection(
             api_root_id=api_root_id, collection_id_or_alias=collection_id_or_alias
         )
         if not collection.can_read(context.account):
             raise NoReadPermission()
-        versions, more = self.api.get_object(
+        versions, more, next_param = self.api.get_object(
             collection_id=collection.id,
             object_id=object_id,
             limit=limit,
@@ -563,7 +563,7 @@ class Taxii2PersistenceManager(BasePersistenceManager):
         )
         if versions is None:
             raise DoesNotExistError()
-        return (versions, more)
+        return (versions, more, next_param)
 
     def delete_object(
         self,

--- a/opentaxii/persistence/sqldb/api.py
+++ b/opentaxii/persistence/sqldb/api.py
@@ -1023,7 +1023,7 @@ class Taxii2SQLDatabaseAPI(BaseSQLDatabaseAPI, OpenTAXII2PersistenceAPI):
         match_spec_version: Optional[List[str]] = None,
     ) -> Tuple[Optional[List[entities.STIXObject]], bool, Optional[str]]:
         """
-        Get all versions of single object from database.
+        Get single object from database.
 
         Should return `None` when object matching object_id doesn't exist.
         """
@@ -1100,6 +1100,11 @@ class Taxii2SQLDatabaseAPI(BaseSQLDatabaseAPI, OpenTAXII2PersistenceAPI):
         next_kwargs: Optional[Dict] = None,
         match_spec_version: Optional[List[str]] = None,
     ) -> Tuple[List[entities.VersionRecord], bool]:
+        """
+        Get all versions of single object from database.
+
+        Should return `None` when object matching object_id doesn't exist.
+        """
         if (
             not self.db.session.query(literal(True))
             .filter(

--- a/opentaxii/taxii2/entities.py
+++ b/opentaxii/taxii2/entities.py
@@ -1,5 +1,6 @@
 """Taxii2 entities."""
 from datetime import datetime
+from typing import Optional
 
 from opentaxii.common.entities import Entity
 from opentaxii.entities import Account
@@ -45,13 +46,17 @@ class Collection(Entity):
         self.description = description
         self.alias = alias
 
-    def can_read(self, account: Account):
+    def can_read(self, account: Optional[Account]):
         """Determine if `account` is allowed to read from this collection."""
-        return account.is_admin or "read" in set(account.permissions.get(self.id, []))
+        return account and (
+            account.is_admin or "read" in set(account.permissions.get(self.id, []))
+        )
 
-    def can_write(self, account: Account):
+    def can_write(self, account: Optional[Account]):
         """Determine if `account` is allowed to write to this collection."""
-        return account.is_admin or "write" in set(account.permissions.get(self.id, []))
+        return account and (
+            account.is_admin or "write" in set(account.permissions.get(self.id, []))
+        )
 
 
 class STIXObject(Entity):

--- a/opentaxii/taxii2/entities.py
+++ b/opentaxii/taxii2/entities.py
@@ -173,7 +173,15 @@ class JobDetail(Entity):
     :param str status: status of this job
     """
 
-    def __init__(self, id: str, job_id: str, stix_id: str, version: datetime, message: str, status: str):
+    def __init__(
+        self,
+        id: str,
+        job_id: str,
+        stix_id: str,
+        version: datetime,
+        message: str,
+        status: str,
+    ):
         """Initialize JobDetail."""
         self.id = id
         self.job_id = job_id

--- a/opentaxii/taxii2/utils.py
+++ b/opentaxii/taxii2/utils.py
@@ -1,10 +1,5 @@
 """Utility functions for taxii2."""
-import base64
 import datetime
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from opentaxii.taxii2.entities import STIXObject
 
 DATETIMEFORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
@@ -19,26 +14,3 @@ def taxii2_datetimeformat(input_value: datetime.datetime) -> str:
     :rtype: string
     """
     return input_value.astimezone(datetime.timezone.utc).strftime(DATETIMEFORMAT)
-
-
-def get_next_param(obj: "STIXObject") -> bytes:
-    """
-    Get value for `next` based on :class:`STIXObject` instance.
-
-    :param :class:`STIXObject` obj: The object to base the `next` param on
-
-    :return: The value to use as `next` param
-    :rtype: str
-    """
-    return base64.b64encode(f"{obj.date_added.isoformat()}|{obj.id}".encode("utf-8"))
-
-
-def parse_next_param(next_param: bytes):
-    """
-    Parse provided `next_param` into kwargs to be used to filter stix objects.
-    """
-    date_added_str, obj_id = base64.b64decode(next_param).decode().split("|")
-    date_added = datetime.datetime.strptime(
-        date_added_str.split('+')[0], "%Y-%m-%dT%H:%M:%S.%f"
-    ).replace(tzinfo=datetime.timezone.utc)
-    return {"id": obj_id, "date_added": date_added}

--- a/tests/taxii2/test_taxii2_manifest.py
+++ b/tests/taxii2/test_taxii2_manifest.py
@@ -5,9 +5,10 @@ from urllib.parse import urlencode
 from uuid import uuid4
 
 import pytest
-from opentaxii.taxii2.utils import get_next_param, taxii2_datetimeformat
+from opentaxii.taxii2.utils import taxii2_datetimeformat
 from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, GET_COLLECTION_MOCK,
-                                GET_MANIFEST_MOCK, NOW, STIX_OBJECTS)
+                                GET_MANIFEST_MOCK, GET_NEXT_PARAM, NOW,
+                                STIX_OBJECTS)
 
 
 @pytest.mark.parametrize(
@@ -233,7 +234,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, GET_COLLECTION_MOCK,
             {"Accept": "application/taxii+json;version=2.1"},
             API_ROOTS[0].id,
             COLLECTIONS[5].id,
-            {"next": get_next_param(STIX_OBJECTS[0])},
+            {"next": GET_NEXT_PARAM({"id": STIX_OBJECTS[0].id, "date_added": STIX_OBJECTS[0].date_added})},
             200,
             {
                 "Content-Type": "application/taxii+json;version=2.1",

--- a/tests/taxii2/test_taxii2_object.py
+++ b/tests/taxii2/test_taxii2_object.py
@@ -5,11 +5,10 @@ from urllib.parse import urlencode
 from uuid import uuid4
 
 import pytest
-from opentaxii.taxii2.utils import (DATETIMEFORMAT, get_next_param,
-                                    taxii2_datetimeformat)
+from opentaxii.taxii2.utils import DATETIMEFORMAT, taxii2_datetimeformat
 from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
-                                GET_COLLECTION_MOCK, GET_OBJECT_MOCK, NOW,
-                                STIX_OBJECTS)
+                                GET_COLLECTION_MOCK, GET_NEXT_PARAM,
+                                GET_OBJECT_MOCK, NOW, STIX_OBJECTS)
 
 
 @pytest.mark.parametrize(
@@ -204,7 +203,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
             },
             {
                 "more": True,
-                "next": get_next_param(STIX_OBJECTS[0]).decode(),
+                "next": GET_NEXT_PARAM({"id": STIX_OBJECTS[0].id, "date_added": STIX_OBJECTS[0].date_added}),
                 "objects": [
                     {
                         "id": obj.id,
@@ -300,7 +299,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
             API_ROOTS[0].id,
             COLLECTIONS[5].id,
             STIX_OBJECTS[0].id,
-            {"next": get_next_param(STIX_OBJECTS[0])},
+            {"next": GET_NEXT_PARAM({"id": STIX_OBJECTS[0].id, "date_added": STIX_OBJECTS[0].date_added})},
             200,
             {
                 "Content-Type": "application/taxii+json;version=2.1",
@@ -315,7 +314,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
             COLLECTIONS[5].id,
             STIX_OBJECTS[0].id,
             {
-                "next": get_next_param(STIX_OBJECTS[0]),
+                "next": GET_NEXT_PARAM({"id": STIX_OBJECTS[0].id, "date_added": STIX_OBJECTS[0].date_added}),
                 "match[version]": "all",
             },
             200,

--- a/tests/taxii2/test_taxii2_objects.py
+++ b/tests/taxii2/test_taxii2_objects.py
@@ -5,10 +5,11 @@ from urllib.parse import urlencode
 from uuid import uuid4
 
 import pytest
-from opentaxii.taxii2.utils import get_next_param, taxii2_datetimeformat
+from opentaxii.taxii2.utils import taxii2_datetimeformat
 from tests.taxii2.utils import (ADD_OBJECTS_MOCK, API_ROOTS, COLLECTIONS,
                                 GET_COLLECTION_MOCK, GET_JOB_AND_DETAILS_MOCK,
-                                GET_OBJECTS_MOCK, JOBS, NOW, STIX_OBJECTS)
+                                GET_NEXT_PARAM, GET_OBJECTS_MOCK, JOBS, NOW,
+                                STIX_OBJECTS)
 
 
 @pytest.mark.parametrize(
@@ -160,7 +161,7 @@ from tests.taxii2.utils import (ADD_OBJECTS_MOCK, API_ROOTS, COLLECTIONS,
             },
             {
                 "more": True,
-                "next": get_next_param(STIX_OBJECTS[0]).decode(),
+                "next": GET_NEXT_PARAM({"id": STIX_OBJECTS[0].id, "date_added": STIX_OBJECTS[0].date_added}),
                 "objects": [
                     {
                         "id": obj.id,
@@ -254,7 +255,7 @@ from tests.taxii2.utils import (ADD_OBJECTS_MOCK, API_ROOTS, COLLECTIONS,
             {"Accept": "application/taxii+json;version=2.1"},
             API_ROOTS[0].id,
             COLLECTIONS[5].id,
-            {"next": get_next_param(STIX_OBJECTS[0])},
+            {"next": GET_NEXT_PARAM({"id": STIX_OBJECTS[0].id, "date_added": STIX_OBJECTS[0].date_added})},
             {},
             200,
             {

--- a/tests/taxii2/test_taxii2_sqldb.py
+++ b/tests/taxii2/test_taxii2_sqldb.py
@@ -4,8 +4,7 @@ from uuid import uuid4
 import pytest
 from opentaxii.persistence.sqldb.taxii2models import Job, JobDetail, STIXObject
 from opentaxii.taxii2 import entities
-from opentaxii.taxii2.utils import (DATETIMEFORMAT, get_next_param,
-                                    parse_next_param)
+from opentaxii.taxii2.utils import DATETIMEFORMAT
 from tests.taxii2.utils import (API_ROOTS, API_ROOTS_WITH_DEFAULT,
                                 API_ROOTS_WITHOUT_DEFAULT, COLLECTIONS,
                                 GET_API_ROOT_MOCK, GET_COLLECTION_MOCK,
@@ -224,7 +223,7 @@ def test_get_collection(taxii2_sqldb_api, db_collections, api_root_id, collectio
             COLLECTIONS[5].id,  # collection_id
             None,  # limit
             None,  # added_after
-            parse_next_param(get_next_param(STIX_OBJECTS[0])),  # next_kwargs
+            {"id": STIX_OBJECTS[0].id, "date_added": STIX_OBJECTS[0].date_added},  # next_kwargs
             None,  # match_id
             None,  # match_type
             None,  # match_version
@@ -517,7 +516,7 @@ def test_get_manifest(
             COLLECTIONS[5].id,  # collection_id
             None,  # limit
             None,  # added_after
-            parse_next_param(get_next_param(STIX_OBJECTS[0])),  # next_kwargs
+            {"id": STIX_OBJECTS[0].id, "date_added": STIX_OBJECTS[0].date_added},  # next_kwargs
             None,  # match_id
             None,  # match_type
             None,  # match_version
@@ -997,7 +996,7 @@ def test_add_objects(
             STIX_OBJECTS[0].id,  # object_id
             None,  # limit
             None,  # added_after
-            parse_next_param(get_next_param(STIX_OBJECTS[0])),  # next_kwargs
+            {"id": STIX_OBJECTS[0].id, "date_added": STIX_OBJECTS[0].date_added},  # next_kwargs
             None,  # match_version
             None,  # match_spec_version
             id="next",
@@ -1007,7 +1006,7 @@ def test_add_objects(
             STIX_OBJECTS[0].id,  # object_id
             None,  # limit
             None,  # added_after
-            parse_next_param(get_next_param(STIX_OBJECTS[0])),  # next_kwargs
+            {"id": STIX_OBJECTS[0].id, "date_added": STIX_OBJECTS[0].date_added},  # next_kwargs
             ["all"],  # match_version
             None,  # match_spec_version
             id="next, all",
@@ -1301,7 +1300,7 @@ def test_delete_object(
             STIX_OBJECTS[0].id,  # object_id
             None,  # limit
             None,  # added_after
-            parse_next_param(get_next_param(STIX_OBJECTS[0])),  # next_kwargs
+            {"id": STIX_OBJECTS[0].id, "date_added": STIX_OBJECTS[0].date_added},  # next_kwargs
             None,  # match_spec_version
             id="next",
         ),
@@ -1363,3 +1362,24 @@ def test_get_versions(
         next_kwargs=next_kwargs,
         match_spec_version=match_spec_version,
     )
+
+
+@pytest.mark.parametrize(
+    "stix_id, date_added, next_param",
+    [
+        pytest.param(
+            "indicator--fa641b92-94d7-42dd-aa0e-63cfe1ee148a",
+            datetime.datetime(
+                2022, 2, 4, 18, 40, 6, 297204, tzinfo=datetime.timezone.utc
+            ),
+            (
+                "MjAyMi0wMi0wNFQxODo0MDowNi4yOTcyMDQrMDA6MDB8aW5kaWNhdG9yLS1mYTY0M"
+                "WI5Mi05NGQ3LTQyZGQtYWEwZS02M2NmZTFlZTE0OGE="
+            ),
+            id="simple",
+        ),
+    ],
+)
+def test_next_param(taxii2_sqldb_api, stix_id, date_added, next_param):
+    assert taxii2_sqldb_api.get_next_param({"id": stix_id, "date_added": date_added}) == next_param
+    assert taxii2_sqldb_api.parse_next_param(next_param) == {"id": stix_id, "date_added": date_added}

--- a/tests/taxii2/test_taxii2_utils.py
+++ b/tests/taxii2/test_taxii2_utils.py
@@ -1,9 +1,7 @@
 import datetime
 
 import pytest
-from opentaxii.taxii2.utils import (get_next_param, parse_next_param,
-                                    taxii2_datetimeformat)
-from tests.taxii2.factories import STIXObjectFactory
+from opentaxii.taxii2.utils import taxii2_datetimeformat
 
 
 @pytest.mark.parametrize(
@@ -74,29 +72,3 @@ from tests.taxii2.factories import STIXObjectFactory
 )
 def test_taxii2_datetimeformat(input_value, expected):
     assert taxii2_datetimeformat(input_value) == expected
-
-
-@pytest.mark.parametrize(
-    "stix_id, date_added, next_param",
-    [
-        pytest.param(
-            "indicator--fa641b92-94d7-42dd-aa0e-63cfe1ee148a",
-            datetime.datetime(
-                2022, 2, 4, 18, 40, 6, 297204, tzinfo=datetime.timezone.utc
-            ),
-            (
-                b"MjAyMi0wMi0wNFQxODo0MDowNi4yOTcyMDQrMDA6MDB8aW5kaWNhdG9yLS1mYTY0M"
-                b"WI5Mi05NGQ3LTQyZGQtYWEwZS02M2NmZTFlZTE0OGE="
-            ),
-            id="simple",
-        ),
-    ],
-)
-def test_next_param(stix_id, date_added, next_param):
-    stix_object = STIXObjectFactory.build(
-        id=stix_id,
-        type=stix_id.split("--")[0],
-        date_added=date_added,
-    )
-    assert get_next_param(stix_object) == next_param
-    assert parse_next_param(next_param) == {"id": stix_id, "date_added": date_added}

--- a/tests/taxii2/test_taxii2_versions.py
+++ b/tests/taxii2/test_taxii2_versions.py
@@ -5,9 +5,10 @@ from urllib.parse import urlencode
 from uuid import uuid4
 
 import pytest
-from opentaxii.taxii2.utils import get_next_param, taxii2_datetimeformat
+from opentaxii.taxii2.utils import taxii2_datetimeformat
 from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, GET_COLLECTION_MOCK,
-                                GET_VERSIONS_MOCK, NOW, STIX_OBJECTS)
+                                GET_NEXT_PARAM, GET_VERSIONS_MOCK, NOW,
+                                STIX_OBJECTS)
 
 
 @pytest.mark.parametrize(
@@ -183,7 +184,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, GET_COLLECTION_MOCK,
             API_ROOTS[0].id,
             COLLECTIONS[5].id,
             STIX_OBJECTS[0].id,
-            {"next": get_next_param(STIX_OBJECTS[0])},
+            {"next": GET_NEXT_PARAM({"id": STIX_OBJECTS[0].id, "date_added": STIX_OBJECTS[0].date_added})},
             200,
             {
                 "Content-Type": "application/taxii+json;version=2.1",


### PR DESCRIPTION
This was in the wrong place. A parameter that's used to paginate the data coming from the database layer should be defined in the database layer, not the http layer :facepalm: 