### PR TITLE
fix: spec_version & version from modified/created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+venv/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/opentaxii/persistence/sqldb/api.py
+++ b/opentaxii/persistence/sqldb/api.py
@@ -977,9 +977,24 @@ class Taxii2SQLDatabaseAPI(BaseSQLDatabaseAPI, OpenTAXII2PersistenceAPI):
         self.db.session.commit()
         job_details = []
         for obj in objects:
-            version = datetime.datetime.strptime(
-                obj["modified"], DATETIMEFORMAT
-            ).replace(tzinfo=datetime.timezone.utc)
+            version = None
+            if "modified" in obj:
+                version = datetime.datetime.strptime(
+                    obj["modified"], DATETIMEFORMAT
+                ).replace(tzinfo=datetime.timezone.utc)
+            elif "created" in obj:
+                version = datetime.datetime.strptime(
+                    obj["created"], DATETIMEFORMAT
+                ).replace(tzinfo=datetime.timezone.utc)
+            else:
+                # If a STIX object is not versioned (and therefore does not have a modified
+                # timestamp) then this version parameter MUST use the created timestamp. If
+                # an object does not have a created or modified timestamp or any other
+                # version information that can be used, then the server should use a value for
+                # the version that is consistent to the server.
+                # -- TAXII 2.1 specification --
+                raise ValueError("STIX object MUST have `modified` or `created` timestamp "
+                                 "in order to create version")
             if (
                 not self.db.session.query(literal(True))
                 .filter(

--- a/opentaxii/server.py
+++ b/opentaxii/server.py
@@ -538,7 +538,7 @@ class TAXII2Server(BaseTAXIIServer):
             response["collections"] = []
             for collection in collections:
                 data = {
-                    "id": collection.id,
+                    "id": str(collection.id),
                     "title": collection.title,
                     "can_read": collection.can_read(context.account),
                     "can_write": collection.can_write(context.account),
@@ -567,7 +567,7 @@ class TAXII2Server(BaseTAXIIServer):
         if context.account is None and not collection.can_read(context.account):
             raise Unauthorized()
         response = {
-            "id": collection.id,
+            "id": str(collection.id),
             "title": collection.title,
             "can_read": collection.can_read(context.account),
             "can_write": collection.can_write(context.account),
@@ -655,7 +655,7 @@ class TAXII2Server(BaseTAXIIServer):
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in objects
@@ -738,7 +738,7 @@ class TAXII2Server(BaseTAXIIServer):
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in versions

--- a/opentaxii/taxii2/entities.py
+++ b/opentaxii/taxii2/entities.py
@@ -63,14 +63,14 @@ class Collection(Entity):
         return self.is_public or (
             account
             and (
-                account.is_admin or "read" in set(account.permissions.get(self.id, []))
+                account.is_admin or "read" in account.permissions.get(str(self.id), [])
             )
         )
 
     def can_write(self, account: Optional[Account]):
         """Determine if `account` is allowed to write to this collection."""
         return account and (
-            account.is_admin or "write" in set(account.permissions.get(self.id, []))
+            account.is_admin or "write" in account.permissions.get(str(self.id), [])
         )
 
 
@@ -185,7 +185,7 @@ class JobDetail(Entity):
 
     def as_taxii2_dict(self):
         """Turn this object into a taxii2 dict."""
-        response = {"id": self.stix_id, "version": taxii2_datetimeformat(self.version)}
+        response = {"id": str(self.stix_id), "version": taxii2_datetimeformat(self.version)}
         if self.message:
             response["message"] = self.message
         return response
@@ -243,7 +243,7 @@ class Job(Entity):
     def as_taxii2_dict(self):
         """Turn this object into a taxii2 dict."""
         response = {
-            "id": self.id,
+            "id": str(self.id),
             "status": self.status,
             "request_timestamp": taxii2_datetimeformat(self.request_timestamp),
             "total_count": self.total_count,

--- a/tests/taxii2/test_taxii2_object.py
+++ b/tests/taxii2/test_taxii2_object.py
@@ -43,7 +43,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in [STIX_OBJECTS[0]]
@@ -70,7 +70,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in [STIX_OBJECTS[0]]
@@ -104,7 +104,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in [STIX_OBJECTS[2]]
@@ -177,7 +177,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:1]
@@ -210,7 +210,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:1]
@@ -242,7 +242,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in [STIX_OBJECTS[0], STIX_OBJECTS[2]]
@@ -269,7 +269,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in [STIX_OBJECTS[0]]
@@ -341,7 +341,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in [STIX_OBJECTS[2]]
@@ -386,7 +386,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:1]
@@ -413,7 +413,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in [STIX_OBJECTS[0]]
@@ -444,7 +444,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in [STIX_OBJECTS[2]]
@@ -473,7 +473,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in [STIX_OBJECTS[0], STIX_OBJECTS[2]]
@@ -514,7 +514,7 @@ from tests.taxii2.utils import (API_ROOTS, COLLECTIONS, DELETE_OBJECT_MOCK,
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:1]

--- a/tests/taxii2/test_taxii2_objects.py
+++ b/tests/taxii2/test_taxii2_objects.py
@@ -49,7 +49,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:2]
@@ -79,7 +79,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:2]
@@ -111,7 +111,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[1:2]
@@ -176,7 +176,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:1]
@@ -206,7 +206,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:2]
@@ -236,7 +236,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:2]
@@ -291,7 +291,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[1:2]
@@ -338,7 +338,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in [STIX_OBJECTS[0]]
@@ -368,7 +368,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:2]
@@ -396,7 +396,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in [STIX_OBJECTS[0]]
@@ -426,7 +426,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:2]
@@ -454,7 +454,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:1]
@@ -484,7 +484,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:2]
@@ -516,7 +516,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[1:3]
@@ -546,7 +546,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:3]
@@ -580,7 +580,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:3]
@@ -608,7 +608,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:1]
@@ -642,7 +642,7 @@ from tests.utils import SKIP
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in STIX_OBJECTS[:2]


### PR DESCRIPTION
- fix: spec_version bug [issue](https://github.com/eclecticiq/OpenTAXII/issues/237)
- fix: version from modified/created [issue](https://github.com/eclecticiq/OpenTAXII/issues/236)
- fix: bugs with UUID, set and str casting
- add `venv` to `.gitignore`