### PR TITLE
Taxii2 config docs and defaults

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -120,8 +120,12 @@ Properties
           - ``db_connection`` — the database connetion string
           - ``create_tables`` — boolean, if true, create tables on startup
 
-      - ``max_content_length`` — the maximum size of the request body in bytes that the server can support
+      - ``max_content_length`` — the maximum size of the request body in bytes that the server can support. Required field
       - ``allow_custom_properties`` — boolean, if true, allow custom stix2 properties when posting objects (default: true)
+      - ``public_discovery`` - boolean, if true, do not require authentication for discovery of api roots (default: false)
+      - ``title`` - title of the server, returned as part of the discovery of api roots. Required field
+      - ``contact`` - contact for the server, returned as part of the discovery of api roots
+      - ``description`` - description of the server, returned as part of the discovery of api roots
 
     - ``logging`` — logging configuration.
 

--- a/opentaxii/server.py
+++ b/opentaxii/server.py
@@ -476,7 +476,7 @@ class TAXII2Server(BaseTAXIIServer):
 
     @register_handler(r"^/taxii2/$", handles_own_auth=True)
     def discovery_handler(self):
-        if context.account is None and not self.config["public_discovery"]:
+        if context.account is None and not self.config.get("public_discovery", False):
             raise Unauthorized()
         response = {
             "title": self.config["title"],


### PR DESCRIPTION
There are a couple fields used for the taxii2 implementation that aren't described in the configurations docs, making setup a little harder than it should be. There are also a couple fields that are required (otherwise the server throws a 500 error) that aren't described as such.

While I was at it I figured rather than making setting a value for public_discovery required I'd just set it to a default of False. Right now discovery doesn't work at all (throws an error) unless the user explicitly sets an option, so False seemed like a safe default.