### PR TITLE
Fix for “Object of type UUID is not JSON serializable” exception for TAXII2

### DIFF
--- a/opentaxii/taxii2/http.py
+++ b/opentaxii/taxii2/http.py
@@ -1,14 +1,20 @@
 """Taxii2 http helper functions."""
 import json
+import uuid
 from typing import Dict, Optional
 
 from flask import Response, make_response
 
+class JsonUUIDEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, uuid.UUID):
+            return str(obj)
+        return super().default(self, obj)
 
 def make_taxii2_response(data, status: Optional[int] = 200, extra_headers: Optional[Dict] = None) -> Response:
     """Turn input data into valid taxii2 response."""
     if not isinstance(data, str):
-        data = json.dumps(data)
+        data = json.dumps(data, cls=JsonUUIDEncoder)
     response = make_response((data, status))
     response.content_type = "application/taxii+json;version=2.1"
     response.headers.update(extra_headers or {})


### PR DESCRIPTION
Multiple taxii2 endpoints (pretty much anything that prints an id) cause an exception when trying to convert an object that contains UUID to json. This is a minimal fix that handles the UUID encoding by converting to a string first on json conversion.