### PR TITLE
add support for token auth type used by taxii2client

### DIFF
--- a/opentaxii/middleware.py
+++ b/opentaxii/middleware.py
@@ -88,6 +88,11 @@ def _authenticate(server, headers):
 
         token = server.auth.authenticate(username, password)
 
+    # Support `token` type provided by `taxii2client` library
+    # https://github.com/oasis-open/cti-taxii-client/blob/54dabadf1a67517e99e6a8f2961614a2a4f5ad2c/taxii2client/common.py#L138
+    elif auth_type == "token":
+        token = raw_token
+
     elif auth_type == "bearer":
         token = raw_token
     else:


### PR DESCRIPTION
`taxii2client` supports authentication with a `token` header by default.

This change adds it as a valid token type to forward to upstream authentication implementations.

```
from taxii2client.v21 import Server
from taxii2client.common import TokenAuth

api_key = "1234567890"
token_auth = TokenAuth(api_key)
server = Server('https://demo.eclecticiq.com/taxii2/', auth=token_auth)
```

Example Headers:
```
Cf-Visitor: {"scheme":"https"}
User-Agent: taxii2-client/2.3.0
Accept: application/taxii+json;version=2.1
Authorization: Token 12345678936f70aea7c1dc7bc4f6f6cf1bedde77f2aea969fdb50cd123456789
Cdn-Loop: cloudflare
```