### PR TITLE
Update taxii2models.py

### DIFF
--- a/opentaxii/persistence/sqldb/taxii2models.py
+++ b/opentaxii/persistence/sqldb/taxii2models.py
@@ -164,6 +164,10 @@ class STIXObject(Base):
         sqlalchemy.Index("ix_opentaxii_stixobject_date_added_id", date_added, id),
     )
 
+    __mapper_args__ = {
+        "order_by": date_added
+    }
+
     @classmethod
     def from_entity(cls, entity: entities.STIXObject):
         """Generate database model from input entity."""


### PR DESCRIPTION
Here, I need to specify a forced sorting based on the "date_added" field; otherwise, when retrieving data using as_pages(_COLLECTION.get_objects, per_request=limit, added_after=timestamp_filter), I won't be able to obtain all the data.