### PR TITLE
Updated entrypoint.sh with new config conventions

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -67,11 +67,14 @@ cat > "$tmpConfig" <<-EOCONFIG
 
 domain: "${OPENTAXII_DOMAIN}"
 
-persistence_api:
-  class: opentaxii.persistence.sqldb.SQLDatabaseAPI
-  parameters:
-    db_connection: ${P_URL}
-    create_tables: yes
+taxii:
+  persistence_api:
+    class: opentaxii.persistence.sqldb.SQLDatabaseAPI
+    parameters:
+      db_connection: ${P_URL}
+      create_tables: yes
+
+taxii2:
 
 auth_api:
   class: opentaxii.auth.sqldb.SQLDatabaseAPI


### PR DESCRIPTION
Updated `docker/entrypoint.sh` script to accommodate new configuration syntax. This change affects how the `opentaxii.yml` is generated when starting the OpenTAXII container.
The settings are set such that:

- All previous settings for TAXII 1 are preserved.
- TAXII 2 is disabled.