### PR TITLE
Fix error for admin account creation in opentaxii-create-account command

### DIFF
--- a/opentaxii/cli/auth.py
+++ b/opentaxii/cli/auth.py
@@ -21,6 +21,7 @@ def create_account(argv=None):
         account = app.taxii_server.auth.api.create_account(
             username=args.username,
             password=args.password,
+            is_admin=args.admin
         )
         token = app.taxii_server.auth.authenticate(
             username=account.username,


### PR DESCRIPTION
Fixed `opentaxii-create-account` command to support `admin` argument. 