### PR TITLE
Return the correct value of spec_version in response data

### DIFF
--- a/opentaxii/server.py
+++ b/opentaxii/server.py
@@ -669,7 +669,7 @@ class TAXII2Server(BaseTAXIIServer):
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in objects
@@ -752,7 +752,7 @@ class TAXII2Server(BaseTAXIIServer):
                     {
                         "id": obj.id,
                         "type": obj.type,
-                        "spec_version": obj.type,
+                        "spec_version": obj.spec_version,
                         **obj.serialized_data,
                     }
                     for obj in versions


### PR DESCRIPTION
Bug fix to return correct `spec_version` value in response data instead of object type. 