### PR TITLE
Resolve time format conflicts

### DIFF
--- a/opentaxii/persistence/sqldb/api.py
+++ b/opentaxii/persistence/sqldb/api.py
@@ -983,6 +983,8 @@ class Taxii2SQLDatabaseAPI(BaseSQLDatabaseAPI, OpenTAXII2PersistenceAPI):
         self.db.session.commit()
         job_details = []
         for obj in objects:
+            if not obj.get("modified"):
+                obj["modified"] = obj.get("created") or datetime.datetime.now(datetime.timezone.utc).strftime(DATETIMEFORMAT)
             version = datetime.datetime.strptime(
                 obj["modified"], DATETIMEFORMAT
             ).replace(tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
Resolve time format conflicts between `Ingested data` and `STIX object` timestamp