### PR TITLE
Feature-Add default and max pagination limit support to prevent large response errors

### DIFF
--- a/opentaxii/config.py
+++ b/opentaxii/config.py
@@ -64,6 +64,8 @@ class ServerConfig(dict):
         "title",
         "public_discovery",
         "allow_custom_properties",
+        "max_pagination_limit",
+        "default_pagination_limit"
     )
     ALL_VALID_OPTIONS = VALID_BASE_OPTIONS + VALID_TAXII_OPTIONS + VALID_TAXII1_OPTIONS
 

--- a/opentaxii/defaults.yml
+++ b/opentaxii/defaults.yml
@@ -26,6 +26,8 @@ taxii1:
       create_tables: yes
 
 taxii2:
+  default_pagination_limit: 10
+  max_pagination_limit: 1000
 
 logging:
   opentaxii: info

--- a/opentaxii/server.py
+++ b/opentaxii/server.py
@@ -599,6 +599,7 @@ class TAXII2Server(BaseTAXIIServer):
     )
     def manifest_handler(self, api_root_id, collection_id_or_alias):
         filter_params = validate_list_filter_params(request.args, self.persistence.api)
+        filter_params["limit"] = self.config.get("max_pagination_limit") if filter_params.get("limit", self.config.get("max_pagination_limit")) > self.config.get("max_pagination_limit") else filter_params.get("limit", self.config.get("default_pagination_limit"))
         try:
             manifest, more = self.persistence.get_manifest(
                 api_root_id=api_root_id,
@@ -652,6 +653,7 @@ class TAXII2Server(BaseTAXIIServer):
 
     def objects_get_handler(self, api_root_id, collection_id_or_alias):
         filter_params = validate_list_filter_params(request.args, self.persistence.api)
+        filter_params["limit"] = self.config.get("max_pagination_limit") if filter_params.get("limit", self.config.get("max_pagination_limit")) > self.config.get("max_pagination_limit") else filter_params.get("limit", self.config.get("default_pagination_limit"))
         try:
             objects, more, next_param = self.persistence.get_objects(
                 api_root_id=api_root_id,


### PR DESCRIPTION
Support of `default_pagination_limit` and `max_pagination_limit` parameters for manifest and objects get endpoints to avoid errors because of large response size.