### PR TITLE
Fix: broken sphinx build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,6 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.extlinks',
     'sphinx_rtd_theme',
-    'sphinx_search.extension',
     ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,4 @@
-sphinx==4.2.0
-sphinx_rtd_theme==1.0.0
-readthedocs-sphinx-search==0.1.1
-sphinxcontrib-applehelp==1.0.7
+sphinx==8.2.3
+sphinx_rtd_theme==3.0.2
 git+https://github.com/eclecticiq/sqla-graphs.git@py3
 -e .


### PR DESCRIPTION
- Upgraded sphinx and sphinx-rtd-theme to latest versions
- Removed pin on sphinxcontrib-applehelp==1.0.7, as earlier dep conflicts with older versions of sphinx is resolved by upgrading sphinx
- removed readthedocs-sphinx-search==0.1.1; see https://github\[.\]com/readthedocs/readthedocs-sphinx-search/issues/144
  - removed corresponding sphinx_search.extension from conf.py