### PR TITLE
Fix: broken readthedocs build by updating readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ sphinx:
 
 # Explicitly set the version of Python and its requirements
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
-   python: "3.9"
+   python: "3.12"
 
 python:
   install:


### PR DESCRIPTION
- Updated ubuntu version pin
- Updated required python version